### PR TITLE
[Feat] 공통 헤더 컨텍스트 등록 방식 적용

### DIFF
--- a/src/api/taskApi.ts
+++ b/src/api/taskApi.ts
@@ -33,6 +33,7 @@ export async function getTasksByFolder(folderId: string): Promise<Task[]> {
   return tasks.filter((t) => t.folderId === folderId);
 }
 
+
 //POST 모양새(나중에 fetch로 교체)
 export async function createTask(input: TaskCreateInput): Promise<Task> {
   const tasks = loadTasks();
@@ -48,6 +49,8 @@ export async function createTask(input: TaskCreateInput): Promise<Task> {
 
   tasks.unshift(newTask);
   saveTasks(tasks);
+
+  console.log("📦 createTask payload:", input); //저장 됐는지 확인용
 
   //네트워크 흉내(없어도 되는데, 동작 확인용)
   await new Promise((r) => setTimeout(r, 150));

--- a/src/components/Header/AppHeaderAuto.tsx
+++ b/src/components/Header/AppHeaderAuto.tsx
@@ -105,17 +105,19 @@ import PrevSvg from "@/assets/prev.svg?react";
 import { HeaderBase, StatusHeaderBase } from "./HeaderBase";
 import HeaderIconButton from "./HeaderIconButton";
 
+import { useHeaderActions } from "@/contexts/HeaderActionContext";
+
 type AppHeaderAutoProps = {
   onOpenDrawer?: () => void;
   onOpenFolderMenu?: () => void;
-  onComplete?: () => void;
-};
+}; //onComplete?: () => void; 제거
 
 type RootOutletContext = {
   openDrawer?: () => void;
 };
 
-export default function AppHeaderAuto({ onOpenDrawer, onOpenFolderMenu, onComplete }: AppHeaderAutoProps) {
+//onComplete 를 context에서 가져오도록 수정
+export default function AppHeaderAuto({ onOpenDrawer, onOpenFolderMenu}: AppHeaderAutoProps) {
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -127,6 +129,8 @@ export default function AppHeaderAuto({ onOpenDrawer, onOpenFolderMenu, onComple
   const stepRaw = searchParams.get("step");
   const step = Number(stepRaw ?? "1");
   const safeStep = Number.isFinite(step) ? step : 1;
+
+  const { onComplete } = useHeaderActions(); //추가
 
   const noop = () => {};
   const openDrawer = outletContext?.openDrawer ?? onOpenDrawer ?? noop;

--- a/src/contexts/HeaderActionContext.tsx
+++ b/src/contexts/HeaderActionContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "react";
+
+export type HeaderActions = {
+  onComplete: (() => void) | null;
+  setOnComplete: (fn: (() => void) | null) => void;
+};
+
+const HeaderActionContext = createContext<HeaderActions | null>(null);
+
+export function useHeaderActions() {
+  const ctx = useContext(HeaderActionContext);
+  if (!ctx) throw new Error("HeaderActionContext missing");
+  return ctx;
+}
+
+export default HeaderActionContext;

--- a/src/layouts/ProtectedLayout.tsx
+++ b/src/layouts/ProtectedLayout.tsx
@@ -1,11 +1,24 @@
+import { useMemo, useState } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { AppHeaderAuto } from "@/components/Header/index";
+import HeaderActionContext from "@/contexts/HeaderActionContext";
 
 export default function ProtectedLayout() {
   const location = useLocation();
 
   // TODO: 실제 인증 상태로 교체
   const isAuthenticated = true;
+
+  //Header Action Context: 헤더 "완료/저장" 버튼 동작을 페이지에서 등록할 수 있게 함
+  const [onComplete, setOnComplete] = useState<(() => void) | null>(null);
+
+  const headerActionsValue = useMemo(
+    () => ({
+      onComplete,
+      setOnComplete,
+    }),
+    [onComplete]
+  );
 
   // 비인증: 로그인(서비스 첫 화면: /)으로 보내고, 원래 가려던 경로를 state로 보관
   if (!isAuthenticated) {
@@ -18,9 +31,9 @@ export default function ProtectedLayout() {
   }
 
   return (
-    <>
+    <HeaderActionContext.Provider value={headerActionsValue}>
       <AppHeaderAuto />
       <Outlet />
-    </>
+    </HeaderActionContext.Provider>
   );
 }

--- a/src/pages/TaskPage/TaskPage.tsx
+++ b/src/pages/TaskPage/TaskPage.tsx
@@ -5,6 +5,7 @@ import UnderlineBox from "@/components/UnderlineBox";
 import type { TaskCreateInput, TaskPriority } from "@/types/task";
 import { MOCK_FOLDER_ID, mockTasks } from "./mock";
 import { createTask, ensureMockSeed } from "@/api/taskApi";
+import { useHeaderActions } from "@/contexts/HeaderActionContext";
 
 function formatDuration(hours: number, minutes: number) {
   if (hours === 0 && minutes === 0) return "";
@@ -16,40 +17,62 @@ function formatDuration(hours: number, minutes: number) {
 export default function TaskPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const { setOnComplete } = useHeaderActions();
 
+  //========================
   //앱 최초 1회: localStorage에 더미 시드
+  //========================
   useEffect(() => {
     ensureMockSeed(mockTasks);
   }, []);
 
+  //========================
   //URL 쿼리로 step 제어 (1: 입력 / 2: 중요도)
+  //========================
   const stepRaw = searchParams.get("step");
   const step = Number(stepRaw ?? "1");
   const safeStep = step === 2 ? 2 : 1; //step은 1/2만 허용
 
+  //========================
   //STEP1 입력값
+  //========================
   const [title, setTitle] = useState("");
   const [hours, setHours] = useState(0);
   const [minutes, setMinutes] = useState(0);
 
+  //========================
   //STEP2 선택값
+  //========================
   const [priority, setPriority] = useState<TaskPriority | null>(null);
 
+  //========================
   //시간 선택 모달
+  //========================
   const [timeModalOpen, setTimeModalOpen] = useState(false);
 
+  //========================
   //표시용(예: "1시간 20분", "20분")
-  const durationText = useMemo(() => formatDuration(hours, minutes), [hours, minutes]);
+  //========================
+  const durationText = useMemo(
+    () => formatDuration(hours, minutes),
+    [hours, minutes]
+  );
 
+  //========================
   //STEP1 라벨/라인 강조용
+  //========================
   const titleActive = title.trim().length > 0;
   const durationActive = durationText.length > 0;
 
-  //헤더(AppHeaderAuto)에서 다음/저장 버튼 활성화 판단용
+  //========================
+  //헤더(AppHeaderAuto) 버튼 활성화 판단용
+  //========================
   const canNext = titleActive && durationActive;
   const canSave = priority !== null;
 
+  //========================
   //POST로 보낼 payload(모양새)
+  //========================
   const createInput: TaskCreateInput | null = useMemo(() => {
     if (!canSave) return null;
     return {
@@ -60,13 +83,15 @@ export default function TaskPage() {
     };
   }, [canSave, hours, minutes, priority, title]);
 
-  //헤더(AppHeaderAuto)가 참조하는 canNext/canSave를 URL 쿼리에 반영
+  //========================
+  //헤더(AppHeaderAuto)가 참조하는
+  //canNext / canSave를 URL 쿼리에 반영
+  //========================
   useEffect(() => {
     const next = new URLSearchParams(searchParams);
 
     if (!next.get("step")) next.set("step", "1");
 
-    //step에 따라 헤더가 보는 값 분기
     if (safeStep >= 2) {
       next.delete("canNext");
       next.set("canSave", canSave ? "1" : "0");
@@ -82,26 +107,24 @@ export default function TaskPage() {
   }, [canNext, canSave, safeStep]);
 
   //========================
-  //SAVE 트리거(action=save)
+  //헤더 "저장" 버튼 동작 등록
   //========================
   useEffect(() => {
-    const action = searchParams.get("action");
-    if (action !== "save") return;
-    if (!createInput) return;
+    const handleSave = async () => {
+      //step2가 아니면 저장 동작 무시
+      if (safeStep < 2) return;
+      if (!createInput) return;
 
-    (async () => {
       await createTask(createInput);
-
-      //action 제거(중복 실행 방지)
-      const next = new URLSearchParams(searchParams);
-      next.delete("action");
-      setSearchParams(next, { replace: true });
-
-      //저장 후 폴더 페이지로 이동
       navigate("/folder");
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams, createInput]);
+    };
+
+    //⚠️ 실행하지 말고, "함수 자체"만 등록
+    setOnComplete(() => handleSave);
+
+    //페이지 이탈 시 헤더 동작 해제
+    return () => setOnComplete(null);
+  }, [setOnComplete, safeStep, createInput, navigate]);
 
   //========================
   //STEP 1: 할 일 입력
@@ -187,7 +210,6 @@ export default function TaskPage() {
               type="button"
               onClick={() => setPriority(p)}
               className={[
-                //피그마: W335 / H54 / padding 13 10 / radius 8
                 "w-full h-13.5 px-2.5 py-3.25 rounded-lg",
                 "flex items-center justify-between",
                 selected ? "bg-[#F1F1F1]" : "bg-transparent",
@@ -200,10 +222,14 @@ export default function TaskPage() {
               <span
                 className={[
                   "flex h-4.5 w-4.5 items-center justify-center rounded-[20px] border",
-                  selected ? "border-[#B0B0B0] bg-[#B0B0B0]" : "border-[#B0B0B0] bg-transparent",
+                  selected
+                    ? "border-[#B0B0B0] bg-[#B0B0B0]"
+                    : "border-[#B0B0B0] bg-transparent",
                 ].join(" ")}
               >
-                {selected ? <span className="text-gray-100 text-[12px] leading-none">✓</span> : null}
+                {selected ? (
+                  <span className="text-gray-100 text-[12px] leading-none">✓</span>
+                ) : null}
               </span>
             </button>
           );


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호 

- close #9 

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.

- 입력 상태에 따라 헤더 "다음 / 저장" 버튼 활성화 로직 연결
- HeaderActionContext를 도입하여 헤더 저장 버튼과 페이지 저장 로직 분리
- 저장 버튼 클릭 시 할 일 데이터(title, duration, priority)를 localStorage(mock)에 저장 후 폴더 페이지로 이동


### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

- 현재 저장 로직은 mock(localStorage) 기반이며, 추후 API 연동 시 createTask 부분만 교체 예정입니다.
- 헤더는 URL 쿼리(step, canNext, canSave)와 Context 기반 onComplete 액션만 참조하도록 분리했습니다.

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.
<img width="889" height="238" alt="image" src="https://github.com/user-attachments/assets/718abe41-e18a-4220-83e7-1688c2d5e2a1" />
